### PR TITLE
Fix module admin pages failing to load

### DIFF
--- a/classes/module.class.php
+++ b/classes/module.class.php
@@ -417,7 +417,7 @@ class Module {
 	private function _module_data($path = false, $local_name = false) {
 		// Set Module Path
 		if ($path) {
-			$drop = array('/admin', '/classes', '/skin', '/language');
+			$drop = array('/admin', '/classes', '/skin', '/language', '\admin', '\classes', '\skin', '\language');
 			$this->_path = CC_ROOT_DIR.str_replace($drop, '', dirname(str_replace(CC_ROOT_DIR, '', $path)));
 			// Drop trailing slashes
 			if (substr($this->_path, -1) == '/') {


### PR DESCRIPTION
In some cases, such as testing locally on a Windows WAMP stack, modules are recognized but clicking the 'Edit' button for the plugin from 'Manage Plugins' is unable to load the module's admin settings page - the page is simply blank.

Accounting for backslashes in addition to forward slashes in the file path fixes this issue.