### PR TITLE
Support 'autocomplete' types on the checkout form

### DIFF
--- a/skins/foundation/templates/content.checkout.confirm.php
+++ b/skins/foundation/templates/content.checkout.confirm.php
@@ -77,12 +77,12 @@
    <div class="row">
       <div class="small-12 large-6 columns">
          <label for="login-username" class="show-for-medium-up">{$LANG.user.email_address}</label>
-         <input type="text" name="username" id="login-username" placeholder="{$LANG.user.email_address} {$LANG.form.required}" value="{$USERNAME}" required disabled>
+         <input type="text" name="username" id="login-username" placeholder="{$LANG.user.email_address} {$LANG.form.required}" autocomplete="username" value="{$USERNAME}" required disabled>
       </div>
    </div>
    <div class="row">
       <div class="small-12 large-6 columns">
-         <label for="login-password" class="show-for-medium-up">{$LANG.account.password}</label><input type="password" autocomplete="off" name="password" id="login-password" placeholder="{$LANG.account.password} {$LANG.form.required}" required disabled>
+         <label for="login-password" class="show-for-medium-up">{$LANG.account.password}</label><input type="password" name="password" id="login-password" placeholder="{$LANG.account.password} {$LANG.form.required}" autocomplete="current-password" required disabled>
       </div>
    </div>
 </div>
@@ -91,27 +91,27 @@
    <p>{$LANG.account.already_registered} <a href="#" id="checkout_login">{$LANG.account.log_in}</a></p>
    <h3>{$LANG.account.contact_details}</h3>
    <div class="row">
-      <div class="small-4 columns"><label for="user_title" class="show-for-medium-up">{$LANG.user.title}</label><input type="text" name="user[title]" id="user_title"  class="capitalize" value="{$USER.title}" placeholder="{$LANG.user.title}"></div>
+      <div class="small-4 columns"><label for="user_title" class="show-for-medium-up">{$LANG.user.title}</label><input type="text" name="user[title]" id="user_title"  class="capitalize" value="{$USER.title}" placeholder="{$LANG.user.title}" autocomplete="honorific-prefix"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="user_first" class="show-for-medium-up">{$LANG.user.name_first}</label><input type="text" name="user[first_name]" id="user_first"   required value="{$USER.first_name}" placeholder="{$LANG.user.name_first}  {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="user_first" class="show-for-medium-up">{$LANG.user.name_first}</label><input type="text" name="user[first_name]" id="user_first" required value="{$USER.first_name}" placeholder="{$LANG.user.name_first}  {$LANG.form.required}" autocomplete="given-name"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="user_last" class="show-for-medium-up">{$LANG.user.name_last}</label><input type="text" name="user[last_name]" id="user_last"   required value="{$USER.last_name}" placeholder="{$LANG.user.name_last}  {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="user_last" class="show-for-medium-up">{$LANG.user.name_last}</label><input type="text" name="user[last_name]" id="user_last" required value="{$USER.last_name}" placeholder="{$LANG.user.name_last}  {$LANG.form.required}" autocomplete="family-name"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="user_email" class="show-for-medium-up">{$LANG.common.email}</label><input type="text" name="user[email]" id="user_email"  required value="{$USER.email}" placeholder="{$LANG.common.email}  {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="user_email" class="show-for-medium-up">{$LANG.common.email}</label><input type="text" name="user[email]" id="user_email" required value="{$USER.email}" placeholder="{$LANG.common.email}  {$LANG.form.required}" autocomplete="email"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="user_phone" class="show-for-medium-up">{$LANG.address.phone}</label><input type="text" name="user[phone]" id="user_phone"  required value="{$USER.phone}" placeholder="{$LANG.address.phone}  {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="user_phone" class="show-for-medium-up">{$LANG.address.phone}</label><input type="text" name="user[phone]" id="user_phone" required value="{$USER.phone}" placeholder="{$LANG.address.phone}  {$LANG.form.required}" autocomplete="tel"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="user_mobile" class="show-for-medium-up">{$LANG.address.mobile}</label><input type="text" name="user[mobile]" id="user_mobile"  value="{$USER.mobile}" placeholder="{$LANG.address.mobile}"></div>
+      <div class="small-12 large-8 columns"><label for="user_mobile" class="show-for-medium-up">{$LANG.address.mobile}</label><input type="text" name="user[mobile]" id="user_mobile" value="{$USER.mobile}" placeholder="{$LANG.address.mobile}" autocomplete="tel"></div>
    </div>
    <h3>{$LANG.address.billing_address}</h3>
    {if !$ALLOW_DELIVERY_ADDRESS}{$LANG.address.ship_to_billing_only}{/if}
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="addr_company" class="show-for-medium-up">{$LANG.address.company_name}</label><input type="text" name="billing[company_name]" id="addr_company"  value="{$BILLING.company_name}" placeholder="{$LANG.address.company_name}"></div>
+      <div class="small-12 large-8 columns"><label for="addr_company" class="show-for-medium-up">{$LANG.address.company_name}</label><input type="text" name="billing[company_name]" id="addr_company"  value="{$BILLING.company_name}" placeholder="{$LANG.address.company_name}" autocomplete="organization"></div>
    </div>
    <address>
       <div class="row">
@@ -122,17 +122,17 @@
       {/if}
       <div{if $ADDRESS_LOOKUP} class="hide"{/if} id="address_form">
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="addr_line2" class="show-for-medium-up">{$LANG.address.line2}</label><input type="text" name="billing[line2]" id="addr_line2"  value="{$BILLING.line2}" placeholder="{$LANG.address.line2}"></div>
+         <div class="small-12 large-8 columns"><label for="addr_line2" class="show-for-medium-up">{$LANG.address.line2}</label><input type="text" name="billing[line2]" id="addr_line2"  value="{$BILLING.line2}" placeholder="{$LANG.address.line2}" autocomplete="address-line2"></div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="addr_town" class="show-for-medium-up">{$LANG.address.town}</label><input type="text" name="billing[town]" id="addr_town"  required value="{$BILLING.town}" placeholder="{$LANG.address.town} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="addr_town" class="show-for-medium-up">{$LANG.address.town}</label><input type="text" name="billing[town]" id="addr_town"  required value="{$BILLING.town}" placeholder="{$LANG.address.town} {$LANG.form.required}" autocomplete="address-level2"></div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="addr_postcode" class="show-for-medium-up">{$LANG.address.postcode}</label><input type="text" name="billing[postcode]" id="addr_postcode"  class="uppercase required" value="{$BILLING.postcode}" placeholder="{$LANG.address.postcode} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="addr_postcode" class="show-for-medium-up">{$LANG.address.postcode}</label><input type="text" name="billing[postcode]" id="addr_postcode"  class="uppercase required" value="{$BILLING.postcode}" placeholder="{$LANG.address.postcode} {$LANG.form.required}" autocomplete="postal-code"></div>
       </div>
       <div class="row">
          <div class="small-12 large-8 columns"><label for="country-list" class="show-for-medium-up">{$LANG.address.country}</label>
-            <select name="billing[country]" class="nosubmit" rel="state-list" id="country-list">
+            <select name="billing[country]" class="nosubmit" rel="state-list" id="country-list" autocomplete="country-name">
             {foreach from=$COUNTRIES item=country}
             <option value="{$country.numcode}" {$country.selected}>{$country.name}</option>
             {/foreach}
@@ -140,7 +140,7 @@
          </div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="state-list" class="show-for-medium-up">{$LANG.address.state}</label></span><input type="text" name="billing[state]" id="state-list"  required value="{$BILLING.state}"></div>
+         <div class="small-12 large-8 columns"><label for="state-list" class="show-for-medium-up">{$LANG.address.state}</label></span><input type="text" name="billing[state]" id="state-list"  required value="{$BILLING.state}" autocomplete="address-line1"></div>
       </div>
 </div>
 </address>
@@ -163,30 +163,30 @@
 <div class="hide" id="address_delivery">
    <h3>{$LANG.address.delivery_address}</h3>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="del_first" class="show-for-medium-up">{$LANG.user.name_first}</label><input type="text" name="delivery[first_name]" id="del_first"   required value="{$DELIVERY.first_name}" placeholder="{$LANG.user.name_first} {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="del_first" class="show-for-medium-up">{$LANG.user.name_first}</label><input type="text" name="delivery[first_name]" id="del_first"   required value="{$DELIVERY.first_name}" placeholder="{$LANG.user.name_first} {$LANG.form.required}" autocomplete="given-name"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="del_last" class="show-for-medium-up">{$LANG.user.name_last}</label><input type="text" name="delivery[last_name]" id="del_last"   required value="{$DELIVERY.last_name}" placeholder="{$LANG.user.name_last} {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="del_last" class="show-for-medium-up">{$LANG.user.name_last}</label><input type="text" name="delivery[last_name]" id="del_last"   required value="{$DELIVERY.last_name}" placeholder="{$LANG.user.name_last} {$LANG.form.required}" autocomplete="family-name"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="del_company" class="show-for-medium-up">{$LANG.address.company_name}</label><input type="text" name="delivery[company_name]" id="del_company"  value="{$DELIVERY.company_name}" placeholder="{$LANG.user.company_name}"></div>
+      <div class="small-12 large-8 columns"><label for="del_company" class="show-for-medium-up">{$LANG.address.company_name}</label><input type="text" name="delivery[company_name]" id="del_company"  value="{$DELIVERY.company_name}" placeholder="{$LANG.user.company_name}" autocomplete="organization"></div>
    </div>
    <address>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="del_line1" class="show-for-medium-up">{$LANG.address.line1}</label><input type="text" name="delivery[line1]" id="del_line1"  required value="{$DELIVERY.line1}" placeholder="{$LANG.address.line1} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="del_line1" class="show-for-medium-up">{$LANG.address.line1}</label><input type="text" name="delivery[line1]" id="del_line1"  required value="{$DELIVERY.line1}" placeholder="{$LANG.address.line1} {$LANG.form.required}" autocomplete="address-line1"></div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="del_line2" class="show-for-medium-up">{$LANG.address.line2}</label><input type="text" name="delivery[line2]" id="del_line2"  value="{$DELIVERY.line2}" placeholder="{$LANG.address.line2}"></div>
+         <div class="small-12 large-8 columns"><label for="del_line2" class="show-for-medium-up">{$LANG.address.line2}</label><input type="text" name="delivery[line2]" id="del_line2"  value="{$DELIVERY.line2}" placeholder="{$LANG.address.line2}" autocomplete="address-line2"></div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="del_town" class="show-for-medium-up">{$LANG.address.town}</label><input type="text" name="delivery[town]" id="del_town"  required value="{$DELIVERY.town}" placeholder="{$LANG.address.town} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="del_town" class="show-for-medium-up">{$LANG.address.town}</label><input type="text" name="delivery[town]" id="del_town"  required value="{$DELIVERY.town}" placeholder="{$LANG.address.town} {$LANG.form.required}" autocomplete="address-level2"></div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="del_postcode" class="show-for-medium-up">{$LANG.address.postcode}</label><input type="text" name="delivery[postcode]" id="del_postcode"  class="uppercase required" value="{$DELIVERY.postcode}" placeholder="{$LANG.address.postcode} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="del_postcode" class="show-for-medium-up">{$LANG.address.postcode}</label><input type="text" name="delivery[postcode]" id="del_postcode"  class="uppercase required" value="{$DELIVERY.postcode}" placeholder="{$LANG.address.postcode} {$LANG.form.required}" autocomplete="postal-code"></div>
       </div>
       <div class="row">
          <div class="small-12 large-8 columns"><label for="delivery_country" class="show-for-medium-up">{$LANG.address.country}</label>
-            <select name="delivery[country]" id="delivery_country"  class="nosubmit country-list" rel="delivery_state">
+            <select name="delivery[country]" id="delivery_country"  class="nosubmit country-list" rel="delivery_state" autocomplete="country-name">
             {foreach from=$COUNTRIES item=country}
             <option value="{$country.numcode}" {$country.selected_d}>{$country.name}</option>
             {/foreach}
@@ -194,7 +194,7 @@
          </div>
       </div>
       <div class="row">
-         <div class="small-12 large-8 columns"><label for="delivery_state" class="show-for-medium-up">{$LANG.address.state}</label></span><input type="text" name="delivery[state]" id="delivery_state"  required value="{$DELIVERY.state}" placeholder="{$LANG.address.state} {$LANG.form.required}"></div>
+         <div class="small-12 large-8 columns"><label for="delivery_state" class="show-for-medium-up">{$LANG.address.state}</label></span><input type="text" name="delivery[state]" id="delivery_state"  required value="{$DELIVERY.state}" placeholder="{$LANG.address.state} {$LANG.form.required}" autocomplete="address-level1"></div>
       </div>
    </address>
 </div>
@@ -208,10 +208,10 @@
 <div id="account-reg">
    <h3>{$LANG.account.password}</h3>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="reg_password" class="show-for-medium-up">{$LANG.account.password}</label></span><input type="password" autocomplete="off" name="password" id="reg_password"  required  placeholder="{$LANG.account.password} {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="reg_password" class="show-for-medium-up">{$LANG.account.password}</label></span><input type="password" autocomplete="off" name="password" id="reg_password"  required  placeholder="{$LANG.account.password} {$LANG.form.required}" autocomplete="new-password"></div>
    </div>
    <div class="row">
-      <div class="small-12 large-8 columns"><label for="reg_passconf" class="show-for-medium-up">{$LANG.user.password_confirm}</label></span><input type="password" autocomplete="off" name="passconf" id="reg_passconf"  required  placeholder="{$LANG.user.password_confirm} {$LANG.form.required}"></div>
+      <div class="small-12 large-8 columns"><label for="reg_passconf" class="show-for-medium-up">{$LANG.user.password_confirm}</label></span><input type="password" autocomplete="off" name="passconf" id="reg_passconf"  required  placeholder="{$LANG.user.password_confirm} {$LANG.form.required}" autocomplete="new-password"></div>
    </div>
 </div>
 {include file='templates/content.recaptcha.php'}


### PR DESCRIPTION
As outlined in the WhatWG spec [1].

This will ensure perfect form "autofill" behavior from browsers that implement the spec.

Notable exception: address billing line1 was left as "autocomplete=off" to support address lookup functionality, undisturbed by Autofill.

[1] https://html.spec.whatwg.org/multipage/forms.html#autofilling-form-controls:-the-autocomplete-attribute