### PR TITLE
Resolves issue #880

### DIFF
--- a/skins/foundation/js/2.cubecart.js
+++ b/skins/foundation/js/2.cubecart.js
@@ -304,6 +304,7 @@ function init_add_to_basket() {
 
 function price_inc_options() {
     var action = $('form.add_to_basket').attr('action');
+    var absolute = false;
     var total = 0;
     var ptp = parseFloat($('#ptp').attr("data-price"));
     var fbp = parseFloat($('#fbp').attr("data-price"));
@@ -321,20 +322,20 @@ function price_inc_options() {
     $("[name^=productOptions]").each(function () {
         
         if($(this).is('input:radio') && $(this).is(':checked')) {
-            if($(this).hasClass('absolute')) { total = ptp = 0; }
+            if($(this).hasClass('absolute')) { total = ptp = 0; absolute = true; }
             total += parseFloat($(this).attr("data-price"));
         } else if ($(this).is('select') && $(this).val()) {
-            if($("option:selected", this).hasClass('absolute')) { total = ptp = 0; }
+            if($("option:selected", this).hasClass('absolute')) { total = ptp = 0; absolute = true; }
             total += parseFloat($(this).find("option:selected").attr("data-price"));
         } else if (($(this).is('textarea') || $(this).is('input:text')) && $(this).val() !== '') {
-            if($(this).hasClass('absolute')) { total = ptp = 0; }
+            if($(this).hasClass('absolute')) { total = ptp = 0; absolute = true; }
             total += parseFloat($(this).attr("data-price"));
         }
     });
-    ptp += total;
+    ptp = (absolute ? total : ptp + total);
 
     if($('#fbp').length > 0) {
-        fbp += total;
+        fbp = (absolute ? total : fbp + total);
         $.ajax({
             url: action + ptp + '&price[1]='+ fbp,
             cache: true,
@@ -342,6 +343,13 @@ function price_inc_options() {
                 var prices = $.parseJSON(returned.responseText);
                 $('#ptp').html(prices[0]);
                 $('#fbp').html(prices[1]);
+                if (absolute && prices[0] <= prices[1]) {
+                    $('#fbp').hide();
+                    $('#ptp').removeClass('sale_price');
+                } else {
+                    $('#fbp').show();
+                    $('#ptp').addClass('sale_price');
+                }
             }
         });
     } else {


### PR DESCRIPTION
This fixes the absolute price being added to the regular price and then showing up as on sale for the absolute price.

Product options with an absolute price cannot be on sale with this solution, which is consistent with current CubeCart behavior (at least as far as I can surmise).

Regular option on sale:
![cc_880_fix1](https://cloud.githubusercontent.com/assets/14335170/10675067/0c30e2f0-78b3-11e5-97cb-b04a6b6f35f2.png)

Option with absolute price (on sale, but not on sale):
![cc_880_fix2](https://cloud.githubusercontent.com/assets/14335170/10675088/1dff7064-78b3-11e5-8d82-2c4763bc0df0.png)
