### PR TITLE
Centralize product:option modifier logic

### DIFF
--- a/classes/cart.class.php
+++ b/classes/cart.class.php
@@ -714,6 +714,7 @@ class Cart {
 							# 'Recipient' => $item['certificate']['name'],
 							# 'Message' => $item['certificate']['message'],
 						),
+						'option_price_ignoring_tax' => 0,
 					);
 					$product['price_display'] = $product['price'];
 				}


### PR DESCRIPTION
Just some refactoring that maintains current CubeCart behavior regarding how options are applied while centralizing the actual logic. Reduced code duplication = easier to make changes, debug, etc.

I decided to make the function public and static so that it may be used from elsewhere, for example to determine option pricing when dynamically updating the product view via AJAX when no cart is available.