### PR TITLE
Fix error log message spam on every page load

### DIFF
--- a/admin/sources/settings.errorlog.inc.php
+++ b/admin/sources/settings.errorlog.inc.php
@@ -56,9 +56,9 @@ if (is_array($error_log)) {
 			'style'  => $log['read'] ? '' : 'style="font-weight: bold"'
 		);
 	}
+	$GLOBALS['smarty']->assign('ADMIN_ERROR_LOG', $smarty_data['error_log']);
 }
 
-$GLOBALS['smarty']->assign('ADMIN_ERROR_LOG', $smarty_data['error_log']);
 $count = $GLOBALS['db']->count('CubeCart_admin_error_log', 'log_id', array('admin_id' => Admin::getInstance()->get('admin_id')));
 $GLOBALS['smarty']->assign('PAGINATION_ADMIN_ERROR_LOG', $GLOBALS['db']->pagination($count, $per_page, $page, 5, 'page', 'admin_error_log'));
 


### PR DESCRIPTION
The fix assumes that $smarty_data is not instantiated elsewhere; if it is, then an alternate fix would be to instead nest the assignment within its own condition: `if (isset($smarty_data['error_log'])) {`

Spammed message:
[Notice] /public_html/admin/source/ssettings.errorlog.inc.php:61 - Undefined variable: smarty_data