### PR TITLE
Close gap at certain widths between quantity input and button

### DIFF
--- a/skins/foundation/css/cubecart.css
+++ b/skins/foundation/css/cubecart.css
@@ -121,7 +121,7 @@ td .fa-trash-o,td .fa-trash {
     color: #333
 }
 input.quantity {
-    width: 50px;
+    width: 100%;
     text-align: center;
 }
 div#nav-actions {


### PR DESCRIPTION
Note the gap between the quantity input box and the add to basket button:
![qty_btn_issue](https://cloud.githubusercontent.com/assets/14335170/13611481/a9e84e18-e517-11e5-9827-6e6938287a89.png)
Fixed:
![qty_btn_fix](https://cloud.githubusercontent.com/assets/14335170/13611485/aefc3a18-e517-11e5-92b3-ae9224b027cc.png)
This only appears at certain screen widths, and I'm not sure if this is intentional or not - if it is, ignore this PR.

Also affects the main page product listings:
![qty_btn_issue2](https://cloud.githubusercontent.com/assets/14335170/13611492/bab5e098-e517-11e5-9e08-63ba6ebbc2df.png)
Fixed:
![qty_btn_fix2](https://cloud.githubusercontent.com/assets/14335170/13611494/be6759f6-e517-11e5-8d97-5aa99edfbc26.png)