### PR TITLE
Admin Dashboard Plugin Updates Available Tab

### DIFF
--- a/admin/skins/default/templates/dashboard.index.php
+++ b/admin/skins/default/templates/dashboard.index.php
@@ -264,3 +264,30 @@
       </fieldset>
    </div>
 </div>
+{if $PLUGIN_UPDATES_AVAILABLE}
+<div id="plugin_updates_available" class="tab_content">
+	<h3>{$LANG.dashboard.title_plugin_updates_available}</h3>
+	<table width="100%">
+		<thead>		
+			<tr>
+				<th width="40%">{$LANG.dashboard.pua_heading_plugin_name}</th>
+				<th width="40%">{$LANG.dashboard.pua_heading_plugin_creator}</th>
+				<th width="10%" align="center">{$LANG.dashboard.pua_heading_installed_version}</th>
+				<th width="10%" align="center">{$LANG.dashboard.pua_heading_current_version}</th>
+			</tr>
+		</thead>
+		{foreach from=$PLUGIN_UPDATES item=plugin_update}
+			<tr>
+				<td>
+					<a href="{$plugin_update.plugin_href}" title="{$plugin_update.plugin_name}">{$plugin_update.plugin_name}</a>
+				</td>
+				<td>
+					<a href="{$plugin_update.plugin_creator_href}" title="{$plugin_update.plugin_creator_name}" target="_blank">{$plugin_update.plugin_creator_name}</a>
+				</td>
+				<td align="center" style="color: RED;">{$plugin_update.plugin_installed_version}</td>
+				<td align="center" style="color: GREEN;">{$plugin_update.plugin_current_version}</td>
+			</tr>
+		{/foreach}
+	</table>
+</div>	
+{/if}

--- a/admin/skins/default/templates/dashboard.index.php
+++ b/admin/skins/default/templates/dashboard.index.php
@@ -279,13 +279,13 @@
 		{foreach from=$PLUGIN_UPDATES item=plugin_update}
 			<tr>
 				<td>
-					<a href="{$plugin_update.plugin_href}" title="{$plugin_update.plugin_name}">{$plugin_update.plugin_name}</a>
+					<a href="{$plugin_update.plugin_href}" title="{$plugin_update.plugin_name}">{$plugin_update.plugin_name}</a> - <a href="{$plugin_update.plugin_update_url}" class="update_available" target="_blank" title="{$plugin_update.creator}">{$LANG.dashboard.update_available}</a>
 				</td>
 				<td>
 					<a href="{$plugin_update.plugin_creator_href}" title="{$plugin_update.plugin_creator_name}" target="_blank">{$plugin_update.plugin_creator_name}</a>
 				</td>
-				<td align="center" style="color: RED;">{$plugin_update.plugin_installed_version}</td>
-				<td align="center" style="color: GREEN;">{$plugin_update.plugin_current_version}</td>
+				<td align="center">{$plugin_update.plugin_installed_version}</td>
+				<td align="center">{$plugin_update.plugin_current_version}</td>
 			</tr>
 		{/foreach}
 	</table>

--- a/admin/skins/default/templates/plugins.index.php
+++ b/admin/skins/default/templates/plugins.index.php
@@ -30,7 +30,8 @@
             <tr>
                <th width="10">{$LANG.common.status}</th>
                <th>{$LANG.common.name_and_desc}</th>
-               <th>{$LANG.hooks.version}</th>
+               <th>{$LANG.module.installed_version}</th>
+               <th>{$LANG.module.current_version}</th>
                <th>{$LANG.common.type}</th>
                <th width="10">&nbsp;</th>
             </tr>
@@ -42,8 +43,12 @@
                   <input type="hidden" id="status_{$module.basename}" name="status[{$module.basename}]" value="{$module.config.status}" class="toggle">
                   <input type="hidden" name="type[{$module.basename}]" value="{$module.type}" />
                </td>
-               <td><a href="{$module.edit_url}">{$module.name}</a><br>{$module.description}</td>
+               <td>
+                  <a href="{$module.edit_url}">{$module.name}</a>{if $module.update_available} - <a href="{$module.update_url}" class="update_available" target="_blank" title="{$module.creator}">{$LANG.module.update_available}</a>{/if}
+                  <br>{$module.description}
+               </td>
                <td>{$module.version}</td>
+               <td>{$module.current_version}</td>               
                <td>{$module.type|ucfirst}</td>
                <td nowrap>
                   <a href="{$module.edit_url}" class="edit"><i class="fa fa-pencil-square-o" title="{$LANG.common.edit}"></i></a>

--- a/admin/sources/dashboard.index.inc.php
+++ b/admin/sources/dashboard.index.inc.php
@@ -313,4 +313,14 @@ $GLOBALS['smarty']->assign('COUNT', $count);
 
 $GLOBALS['main']->addTabControl($lang['common']['search'], 'sidebar');
 
+// Plugin Updates Available Tab
+$plugin_updates_available = 0;
+$plugin_updates_list = array();
+foreach ($GLOBALS['hooks']->load('admin.dashboard.plugin_updates_available') as $hook) include $hook;
+if ($plugin_updates_available > 0) {
+	$GLOBALS['main']->addTabControl($lang['dashboard']['title_plugin_updates_available_tab'], 'plugin_updates_available', null, null, $plugin_updates_available);
+	$GLOBALS['smarty']->assign('PLUGIN_UPDATES', $plugin_updates_list);
+	$GLOBALS['smarty']->assign('PLUGIN_UPDATES_AVAILABLE', true);
+}
+
 $page_content = $GLOBALS['smarty']->fetch('templates/dashboard.index.php');

--- a/language/definitions.xml
+++ b/language/definitions.xml
@@ -850,6 +850,12 @@
     <string name="title_list" introduced="5.0.0"><![CDATA[Customer List]]></string>
   </group>
   <group name="dashboard">
+    <string name="title_plugin_updates_available_tab" introduced="5.0.0"><![CDATA[Plugin Updates]]></string>
+    <string name="title_plugin_updates_available" introduced="5.0.0"><![CDATA[Plugin Updates Available]]></string>
+    <string name="pua_heading_plugin_creator" introduced="5.0.0"><![CDATA[Plugin Creator]]></string>
+    <string name="pua_heading_plugin_name" introduced="5.0.0"><![CDATA[Plugin Name]]></string>
+    <string name="pua_heading_installed_version" introduced="5.0.0"><![CDATA[Installed Version]]></string>
+    <string name="pua_heading_current_version" introduced="5.0.0"><![CDATA[Current Version]]></string>  	
     <string name="quick_tour" introduced="6.0.0"><![CDATA[Quick Tour]]></string>
     <string name="tour_welcome" introduced="6.0.0"><![CDATA[Welcome to your store. Please follow this quick tour to help get you started.]]></string>
     <string name="ok_go" introduced="6.0.0"><![CDATA[Ok, lets go!]]></string>

--- a/language/definitions.xml
+++ b/language/definitions.xml
@@ -850,12 +850,13 @@
     <string name="title_list" introduced="5.0.0"><![CDATA[Customer List]]></string>
   </group>
   <group name="dashboard">
-    <string name="title_plugin_updates_available_tab" introduced="5.0.0"><![CDATA[Plugin Updates]]></string>
-    <string name="title_plugin_updates_available" introduced="5.0.0"><![CDATA[Plugin Updates Available]]></string>
-    <string name="pua_heading_plugin_creator" introduced="5.0.0"><![CDATA[Plugin Creator]]></string>
-    <string name="pua_heading_plugin_name" introduced="5.0.0"><![CDATA[Plugin Name]]></string>
-    <string name="pua_heading_installed_version" introduced="5.0.0"><![CDATA[Installed Version]]></string>
-    <string name="pua_heading_current_version" introduced="5.0.0"><![CDATA[Current Version]]></string>  	
+    <string name="title_plugin_updates_available_tab" introduced="6.0.12"><![CDATA[Plugin Updates]]></string>
+    <string name="title_plugin_updates_available" introduced="6.0.12"><![CDATA[Plugin Updates Available]]></string>
+    <string name="pua_heading_plugin_creator" introduced="6.0.12"><![CDATA[Plugin Creator]]></string>
+    <string name="pua_heading_plugin_name" introduced="6.0.12"><![CDATA[Plugin Name]]></string>
+    <string name="pua_heading_installed_version" introduced="6.0.12"><![CDATA[Installed Version]]></string>
+    <string name="pua_heading_current_version" introduced="6.0.12"><![CDATA[Current Version]]></string> 
+    <string name="update_available" introduced="6.0.12"><![CDATA[Update Available!]]></string> 	
     <string name="quick_tour" introduced="6.0.0"><![CDATA[Quick Tour]]></string>
     <string name="tour_welcome" introduced="6.0.0"><![CDATA[Welcome to your store. Please follow this quick tour to help get you started.]]></string>
     <string name="ok_go" introduced="6.0.0"><![CDATA[Ok, lets go!]]></string>
@@ -1360,6 +1361,10 @@
     <string name="query_box" introduced="5.0.0"><![CDATA[Query Box]]></string>
   </group>
   <group name="module">
+    <string name="installed_version" introduced="6.0.12"><![CDATA[Installed Version]]></string>
+    <string name="current_version" introduced="6.0.12"><![CDATA[Current Version]]></string>
+    <string name="unknown_version" introduced="6.0.12"><![CDATA[Unknown]]></string>
+    <string name="update_available" introduced="6.0.12"><![CDATA[Update Available!]]></string>  	
     <string name="package_fail" introduced="6.0.9"><![CDATA[Error: Failed to obtain package information. Please install via FTP.]]></string>
     <string name="plugin_still_exists" introduced="6.0.0"><![CDATA[Plugin still exists. Please delete manually via FTP or hosting filemanager.]]></string>
     <string name="plugin_deleted_successfully" introduced="6.0.0"><![CDATA[Plugin deleted succesfully.]]></string>

--- a/modules/plugins/hooks.xml
+++ b/modules/plugins/hooks.xml
@@ -37,7 +37,6 @@
  <hook trigger="admin.customer.tabs" deprecated="" /> 
  <hook trigger="admin.customer.update" deprecated="" />
  <hook trigger="admin.customer.post_process" deprecated="" />
- <hook trigger="admin.dashboard.plugin_updates_available" deprecated="" /> 
  <hook trigger="admin.dashboard.quick_tasks" deprecated="" />
  <hook trigger="admin.dashboard.stock.post" deprecated="" />
  <hook trigger="admin.dashboard.tabs" deprecated="" />

--- a/modules/plugins/hooks.xml
+++ b/modules/plugins/hooks.xml
@@ -37,6 +37,7 @@
  <hook trigger="admin.customer.tabs" deprecated="" /> 
  <hook trigger="admin.customer.update" deprecated="" />
  <hook trigger="admin.customer.post_process" deprecated="" />
+ <hook trigger="admin.dashboard.plugin_updates_available" deprecated="" /> 
  <hook trigger="admin.dashboard.quick_tasks" deprecated="" />
  <hook trigger="admin.dashboard.stock.post" deprecated="" />
  <hook trigger="admin.dashboard.tabs" deprecated="" />


### PR DESCRIPTION
Implements a standardized method for displaying plugin update available information on a new tab on the admin dashboard and the manage plugins page.