### PR TITLE
Remove extraneous 'priority' element causing sort to fail

### DIFF
--- a/admin/sources/products.index.inc.php
+++ b/admin/sources/products.index.inc.php
@@ -905,6 +905,7 @@ if (isset($_GET['action'])) {
 			if (is_array($option_list)) {
 				uasort($option_list, 'cmpmc');
 				foreach ($option_list as $oid => $array) {
+					unset($array['priority']);
 					uasort($array, 'cmpmc');
 					$option_list[$oid] = $array;
 


### PR DESCRIPTION
Line 900: `$option_list[$assign['option_id']]['priority'] = $group['priority'];` seems to be for sorting by group, however this leaves an extra array element in the option_list array when sorting the individual options:

```
array (size=3) // this is from 2 options, but contains 3 elements... something's amiss
  350 =>
    array (size=23)
      'assign_id' => string '2353' (length=4)
      'product' => string '637' (length=3)
      'option_id' => string '53' (length=2)
      'value_id' => string '350' (length=3)
      'set_member_id' => string '0' (length=1)
      'set_enabled' => string '1' (length=1)
      'option_negative' => string '0' (length=1)
      'option_price' => string '0.00' (length=4)
      'option_weight' => string '0.00' (length=4)
      'option_length' => string '0.00' (length=4)
      'option_height' => string '0.00' (length=4)
      'option_width' => string '0.00' (length=4)
      'matrix_include' => string '1' (length=1)
      'absolute_price' => string '0' (length=1)
      'option_name' => string 'Cable Length' (length=12)
      'option_description' => string '' (length=0)
      'option_type' => string '0' (length=1)
      'option_required' => string '1' (length=1)
      'priority' => string '1' (length=1)
      'display' => string '<strong>Cable Length:</strong> 9'' (length=33)
      'value_name' => string '9'' (length=2)
      'show_disable' => boolean false
      'from_assigned' => boolean true

  // RIGHT HERE
  'priority' => string '1' (length=1)

  351 =>
    array (size=23)
      'assign_id' => string '2354' (length=4)
      'product' => string '637' (length=3)
      'option_id' => string '53' (length=2)
      'value_id' => string '351' (length=3)
      'set_member_id' => string '0' (length=1)
      'set_enabled' => string '1' (length=1)
      'option_negative' => string '0' (length=1)
      'option_price' => string '0.00' (length=4)
      'option_weight' => string '4.00' (length=4)
      'option_length' => string '0.00' (length=4)
      'option_height' => string '0.00' (length=4)
      'option_width' => string '0.00' (length=4)
      'matrix_include' => string '1' (length=1)
      'absolute_price' => string '0' (length=1)
      'option_name' => string 'Cable Length' (length=12)
      'option_description' => string '' (length=0)
      'option_type' => string '0' (length=1)
      'option_required' => string '1' (length=1)
      'priority' => string '2' (length=1)
      'display' => string '<strong>Cable Length:</strong> 14'' (length=34)
      'value_name' => string '14'' (length=3)
      'show_disable' => boolean false
      'from_assigned' => boolean true
```
This would result in the individual options failing to sort as cmpmp function ends up trying to compare '1' to an array and always returns false.