### PR TITLE
Fixes empty options selection from appearing when product has no options

### DIFF
--- a/skins/foundation/templates/content.product.php
+++ b/skins/foundation/templates/content.product.php
@@ -29,6 +29,7 @@
             {/if}
          </div>
          <div class="small-7 medium-5 columns">
+         {if is_array($OPTIONS)}		 
          {foreach from=$OPTIONS item=option}
             {if $option.type == Catalogue::OPTION_RADIO}
             <div class="row">
@@ -82,6 +83,7 @@
             </div>
             {/if}
          {/foreach}
+         {/if}
 
             {if $PRODUCT.review_score && $CTRL_REVIEW}
             <p itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">


### PR DESCRIPTION
Seems that commit 9207337 was a little overzealous in its removal of conditional statements. It would be worth investigating whether e.g. $CRUMBS, $SIDEBAR_CONTENT etc. can ever be empty; if so, then, like $OPTIONS, that should be checked lest a similar result manifest.

Note that in order to focus solely on the issue at hand, this PR does not modify indentation of elements nested within the re-added condition.

Before fix:
![cc_1373](https://cloud.githubusercontent.com/assets/14335170/20768047/5097f212-b6f1-11e6-8163-881ce95dc354.jpg)
