### PR TITLE
Resolves issue #821

### DIFF
--- a/classes/catalogue.class.php
+++ b/classes/catalogue.class.php
@@ -547,10 +547,12 @@ class Catalogue {
 	 * @return array
 	 */
 	public function displaySort($search = false) {
-		
+		// Default sort order
+		$default = array('field'=>$GLOBALS['config']->get('config', 'product_sort_column'), 'sort'=>$GLOBALS['config']->get('config', 'product_sort_direction'));
 		// Sort
 		if ($search || $this->_sort_by_relevance) {
 			$sorters['Relevance'] = $GLOBALS['language']->common['relevance'];
+			$default['field'] = 'Relevance'; // default search order is always 'Relevance'
 		}
 		$sorters['name']  = $GLOBALS['language']->common['name'];
 		$sorters['date_added'] = $GLOBALS['language']->category['sort_date'];
@@ -573,7 +575,7 @@ class Catalogue {
 				$direction = (isset($GLOBALS['language']->category[strtolower('sort_'.$field.'_'.$order)])) ? $GLOBALS['language']->category[strtolower('sort_'.$field.'_'.$order)] : $direction;
 				$assign = array('name' => $name, 'field' => $field, 'order' => $order, 'direction' => $direction);
 
-				if ((isset($_GET['sort'][$field]) && strtoupper($_GET['sort'][$field]) == $order)  || (!isset($_GET['sort']) && $field==$GLOBALS['config']->get('config', 'product_sort_column') && $order==$GLOBALS['config']->get('config', 'product_sort_direction'))) {
+				if ((isset($_GET['sort'][$field]) && strtoupper($_GET['sort'][$field]) == $order) || (!isset($_GET['sort']) && $field == $default['field'] && $order == $default['sort'])) {
 					$assign['selected'] = 'selected="selected"';
 				} else {
 					$assign['selected'] = '';
@@ -1599,6 +1601,7 @@ class Catalogue {
 				//    $where[] = 'I.manufacturer IN ('.implode(',', '\''.$search_data['manufacturer']).'\')';
 			}
 
+			$order = array();
 			if (isset($_GET['sort']) && is_array($_GET['sort'])) {
 				foreach ($_GET['sort'] as $field => $direction) {
 					$order['field'] = $field;
@@ -1615,6 +1618,14 @@ class Catalogue {
 			} elseif ($search_mode == 'fulltext') {
 				$order['field'] = 'Relevance';
 				$order['sort'] = 'DESC';
+			}
+			// Use store settings for sort order if none designated
+			if (empty($order)) {
+				$order['field'] = $GLOBALS['config']->get('config', 'product_sort_column');
+				$order['sort'] = $GLOBALS['config']->get('config', 'product_sort_direction');
+				if (empty($order['field']) || empty($order['sort'])) {
+					unset($order); // store settings were somehow invalid
+				}
 			}
 			if (empty($search_data['keywords']) && $order['field'] == 'Relevance') {
 				if ($sale_mode == 1) {

--- a/classes/catalogue.class.php
+++ b/classes/catalogue.class.php
@@ -1539,7 +1539,7 @@ class Catalogue {
 				if (!empty($search_data['priceMin']) && is_numeric($search_data['priceMin'])) {
 					$price = round($GLOBALS['tax']->priceConvertFX($search_data['priceMin'])/1.05, 3);
 					if ($sale_mode == 1) {
-						$where[] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) >= '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) >= '.$price.')';
+						$where[] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price) >= '.$price.', IF (G.sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price) >= '.$price.')';
 					} else if ($sale_mode == 2) {
 							$where[] = 'IF (G.price IS NULL, (I.price - ((I.price / 100) * '.$sale_percentage.')) >= '.$price.', (G.price - ((G.price / 100) * '.$sale_percentage.')) >= '.$price.')';
 						} else {
@@ -1550,7 +1550,7 @@ class Catalogue {
 				if (!empty($search_data['priceMax']) && is_numeric($search_data['priceMax'])) {
 					$price = round($GLOBALS['tax']->priceConvertFX($search_data['priceMax'])*1.05, 3);
 					if ($sale_mode == 1) {
-						$where[] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) <= '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) <= '.$price.')';
+						$where[] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price) <= '.$price.', IF (G.sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price) <= '.$price.')';
 					} else if ($sale_mode == 2) {
 							$where[] = 'IF (G.price IS NULL, (I.price - ((I.price / 100) * '.$sale_percentage.')) <= '.$price.', (G.price - ((G.price / 100) * '.$sale_percentage.')) <= '.$price.')';
 						} else {
@@ -1564,7 +1564,7 @@ class Catalogue {
 					$search_data['priceMax'] == $search_data['priceMin']) {
 					$price = round($GLOBALS['tax']->priceConvertFX($search_data['priceMin']), 3);
 					if ($sale_mode == 1) {
-						$where[] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) = '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) = '.$price.')';
+						$where[] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price) = '.$price.', IF (G..sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price) = '.$price.')';
 					} else if ($sale_mode == 2) {
 							$where[] = 'IF (G.price IS NULL, (I.price - ((I.price / 100) * '.$sale_percentage.')) = '.$price.', (G.price - ((G.price / 100) * '.$sale_percentage.')) = '.$price.')';
 						} else {
@@ -1574,7 +1574,7 @@ class Catalogue {
 					if (!empty($search_data['priceMin']) && is_numeric($search_data['priceMin'])) {
 						$price = round($GLOBALS['tax']->priceConvertFX($search_data['priceMin']), 3);
 						if ($sale_mode == 1) {
-							$where[] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) >= '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) >= '.$price.')';
+							$where[] = 'IF (G.product_id IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) >= '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) >= '.$price.')';
 						} else if ($sale_mode == 2) {
 								$where[] = 'IF (G.price IS NULL, (I.price - ((I.price / 100) * '.$sale_percentage.')) >= '.$price.', (G.price - ((G.price / 100) * '.$sale_percentage.')) >= '.$price.')';
 							} else {
@@ -1584,7 +1584,7 @@ class Catalogue {
 					if (!empty($search_data['priceMax']) && is_numeric($search_data['priceMax'])) {
 						$price = round($GLOBALS['tax']->priceConvertFX($search_data['priceMax']), 3);
 						if ($sale_mode == 1) {
-							$where[] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price) <= '.$price.', IF (G.sale_price = 0, G.price, G.sale_price) <= '.$price.')';
+							$where[] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price) <= '.$price.', IF (G.sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price) <= '.$price.')';
 						} else if ($sale_mode == 2) {
 								$where[] = 'IF (G.price IS NULL, (I.price - ((I.price / 100) * '.$sale_percentage.')) <= '.$price.', (G.price - ((G.price / 100) * '.$sale_percentage.')) <= '.$price.')';
 							} else {
@@ -1604,9 +1604,9 @@ class Catalogue {
 					$order['field'] = $field;
 					if ($field == 'price') {
 						if ($sale_mode == 1) {
-							$order['field'] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price), IF (G.sale_price = 0, G.price, G.sale_price))';
+							$order['field'] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price), IF (G.sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price))';
 						} else {
-							$order['field'] = 'IF (G.price IS NULL, I.price, G.price)';
+							$order['field'] = 'IFNULL (G.price, I.price)';
 						}
 					}
 					$order['sort'] = (strtolower($direction) == 'asc') ? 'ASC' : 'DESC';
@@ -1618,9 +1618,9 @@ class Catalogue {
 			}
 			if (empty($search_data['keywords']) && $order['field'] == 'Relevance') {
 				if ($sale_mode == 1) {
-					$order['field'] = 'IF (G.sale_price IS NULL, IF (I.sale_price = 0, I.price, I.sale_price), IF (G.sale_price = 0, G.price, G.sale_price))';
+					$order['field'] = 'IF (G.product_id IS NULL, IF (I.sale_price IS NULL OR I.sale_price = 0, I.price, I.sale_price), IF (G.sale_price IS NULL OR G.sale_price = 0, G.price, G.sale_price))';
 				} else {
-					$order['field'] = 'IF (G.price IS NULL, I.price, G.price)';
+					$order['field'] = 'IFNULL (G.price, I.price)';
 				}
 			}
 			if (is_array($order)) {


### PR DESCRIPTION
This commit fixes issues with sorting by price, but does not address category sorting preferences being ignored (I'm not sure where those settings can be found).

Changing search order via the select menu functions correctly (tested name and price, both ASC and DESC) except that the default sort for the initial search appears to be by relevance while the dropdown menu shows 'Name (A-Z)' as the currently selected method. This means that the initial search results appear to be mis-ordered, but it is merely a mis-display of the selected option.

Keying off of `G.product_id` is more correct as it only uses the group pricing if the group itself exists, whereas `G.sale_price` can be null both when the group doesn't exist and when the group doesn't have a sale price.

Furthermore, `sale_price` can have a value of either `null` or `0.00`, both of which should be considered non-values for purposes of sorting by price.