### PR TITLE
Resolves issue with custom category URLs

### DIFF
--- a/classes/seo.class.php
+++ b/classes/seo.class.php
@@ -387,7 +387,7 @@ class SEO {
 				if ($link) {
 					$this->_cat_path[] = '<a href="'.$GLOBALS['storeURL'].'/index.php?_a=category&cat_id='.(int)$category['cat_id'].'">'.$category['cat_name'].'</a>';
 				} else {
-					$this->_cat_path[] = $category['cat_name'];
+					$this->_cat_path[] = (empty($category['path']) ? $category['cat_name'] : $category['path']);
 				}
 				if (is_numeric($category['cat_parent_id']) && $category['cat_parent_id'] != 0) {
 					$this->_cat_path[] = $this->getDirectory($category['cat_parent_id'], $link, $glue, $append, $custom, $noLoops);
@@ -891,7 +891,8 @@ ErrorDocument 404 '.CC_ROOT_REL.'index.php
 		$language = Session::getInstance()->has('language', 'client') ? Session::getInstance()->get('language', 'client') : Language::getInstance()->current();
 		if ($rebuild || ($this->_cat_dirs = Cache::getInstance()->read('seo.category.list.'.$language)) === false) {
 			//   if (($results = $GLOBALS['db']->select('CubeCart_category', array('cat_id', 'cat_name', 'cat_parent_id'), array('hide' => '0'), array('cat_id' => 'DESC'))) !== false) {
-			if (($results = $GLOBALS['db']->select('CubeCart_category', array('cat_id', 'cat_name', 'cat_parent_id'), false, array('cat_id' => 'DESC'))) !== false) {
+			$query = sprintf("SELECT C.cat_id, C.cat_name, C.cat_parent_id, S.path FROM `%1\$sCubeCart_category` as C LEFT JOIN `%1\$sCubeCart_seo_urls` as S ON S.item_id=C.cat_id AND S.type='cat' AND S.custom='1' ORDER BY C.cat_id DESC", $GLOBALS['config']->get('config', 'dbprefix'));
+			if (($results = $GLOBALS['db']->query($query)) !== false) {
 				foreach ($results as $result) {
 					$this->_cat_dirs[$result['cat_id']] = $result;
 				}


### PR DESCRIPTION
Setting a custom category URL works fine, but that custom URL is not used when auto-populating the product SEO URL field.

For example, if I am creating a Product A in Category C, the auto-generated URL for the product is `c/a` which will in turn be used to construct a link to `store_url/c/a.html`. That works fine.

Setting the URL (prior to creating the product) for Category C to `custom`, however, does NOT affect the URL built for the product, so rather than `custom/a` we still get `c/a` as the URL.