### PR TITLE
Remove unneeded lines from search code

### DIFF
--- a/classes/cubecart.class.php
+++ b/classes/cubecart.class.php
@@ -746,13 +746,7 @@ class Cubecart {
 				}
 			}
 		}
-
 		if (isset($_REQUEST['search'])) {
-			if ($_POST['search']) {
-				foreach ($_POST['search'] as $key => $value) {
-					$query['search'][$key] = $value;
-				}
-			}
 			$search = true;
 			// Insert into search records
 			if (isset($_REQUEST['search']['keywords'])) {


### PR DESCRIPTION
As noted in comments for issue #821, this code does not seem to have any function and the line `if ($_POST['search'])` is completely ignored anyway since `$_POST['search']` is an undefined index.