### PR TITLE
Fix issue re-setting category SEO path

### DIFF
--- a/admin/sources/categories.index.inc.php
+++ b/admin/sources/categories.index.inc.php
@@ -78,6 +78,7 @@ if (isset($_POST['cat']) && is_array($_POST['cat']) && Admin::getInstance()->per
 				}
 				if(empty($_POST['seo_path'])) {
 					$GLOBALS['seo']->delete('cat', $cat_id);
+					$GLOBALS['seo']->rebuildCategoryList(); // clear previous entry from SEO class before generating new path
 				}
 				$GLOBALS['seo']->setdbPath('cat', $cat_id, $_POST['seo_path'], false, false);
 				$GLOBALS['seo']->rebuildCategoryList();


### PR DESCRIPTION
The issue is that when setting the db path, it eventually calls `generatePath()` with a valid id but an empty and an seo path that no longer exists in the database, but DOES still exist in `$this->_cat_dirs[$id]`.

In other words, the first time you delete the custom seo path, it keeps the exact same custom path but sets custom to 0; the field must be cleared and saved a second time to finally generate the default seo path.

Rebuilding the category list after deleting the entry but before calling `setDbPath` fixes this by ensuring the ghost entry is removed.