### PR TITLE
Resolves issue #1506 - added admin search_mode config option

### DIFF
--- a/admin/skins/default/templates/settings.index.php
+++ b/admin/skins/default/templates/settings.index.php
@@ -125,6 +125,10 @@
             </select>
             </span>
          </div>
+         <div><label for="catalogue_search_mode">{$LANG.settings.catalogue_search_mode}</label><span><select name="config[catalogue_search_mode]" id="catalogue_search_mode" class="textbox">
+            {foreach from=$OPT_CATALOGUE_SEARCH_MODE item=option}<option value="{$option.value}"{$option.selected}>{$option.title}</option>{/foreach}
+            </select></span>
+         </div>
          <div><label for="catalogue_show_empty">{$LANG.settings.category_display_empty}</label><span><select name="config[catalogue_show_empty]" id="catalogue_show_empty" class="textbox">
             {foreach from=$OPT_CATALOGUE_SHOW_EMPTY item=option}<option value="{$option.value}"{$option.selected}>{$option.title}</option>{/foreach}
             </select></span>

--- a/admin/sources/settings.index.inc.php
+++ b/admin/sources/settings.index.inc.php
@@ -333,6 +333,7 @@ $select_options = array(
 	'basket_allow_non_invoice_address' => null,
 	'catalogue_latest_products'   => null,
 	'catalogue_show_empty' => null,
+	'catalogue_search_mode' => array('fulltext'=>$lang['settings']['catalogue_search_mode_fulltext'],'like'=>$lang['settings']['catalogue_search_mode_like'],'rlike'=>$lang['settings']['catalogue_search_mode_rlike']),
 	'email_smtp'   => null,
 	'ssl'     => null,
 	'stock_level'   => null,

--- a/classes/catalogue.class.php
+++ b/classes/catalogue.class.php
@@ -1568,8 +1568,10 @@ class Catalogue {
 	 * @param string $search_mode
 	 * @return bool
 	 */
-	public function searchCatalogue($search_data = null, $page = 1, $per_page = 10, $search_mode = 'fulltext') {
-
+	public function searchCatalogue($search_data = null, $page = 1, $per_page = 10, $search_mode = null) {
+		if ($search_mode === null) {
+			$search_mode = $GLOBALS['config']->get('config', 'catalogue_search_mode');
+		}
 		$per_page = (!is_numeric($per_page) || $per_page < 1) ? 10 : $per_page;
 
 		$original_search_data = $search_data;

--- a/language/definitions.xml
+++ b/language/definitions.xml
@@ -1766,6 +1766,10 @@
     <string name="category_name" introduced="5.0.0"><![CDATA[Category Name]]></string>
     <string name="category_parent" introduced="5.0.0"><![CDATA[Parent Category]]></string>
     <string name="catalogue_mode" introduced="5.0.0"><![CDATA[Disable Checkout (Catalogue Mode Only)]]></string>
+    <string name="catalogue_search_mode" introduced="6.1.6"><![CDATA[Search Mode]]></string>
+    <string name="catalogue_search_mode_fulltext" introduced="6.1.6"><![CDATA[Full Text (Sort by relevance, search term must be at least 4 characters)]]></string>
+    <string name="catalogue_search_mode_like" introduced="6.1.6"><![CDATA[Like (Cannot sort by relevance, search term may be any length)]]></string>
+    <string name="catalogue_search_mode_rlike" introduced="6.1.6"><![CDATA[RLike (Cannot sort by relevance, search term may be any length)]]></string>
     <string name="changes_not_made" introduced="5.0.0"><![CDATA[No changes have been made.]]></string>
     <string name="check" introduced="5.0.0"><![CDATA[Check]]></string>
     <string name="cookie_dialogue" introduced="5.0.0"><![CDATA[Enable EU Cookie Compliance]]></string>


### PR DESCRIPTION
Here is a quick screenshot:
![cc_1506](https://cloud.githubusercontent.com/assets/14335170/23035390/c45ff5c6-f433-11e6-8530-fa8ee34bf915.jpg)

I do wonder if we couldn't somehow get the best of both worlds:

- `fulltext` search is great for when you are not searching by product code or terms that would match almost exactly but fails to return any results for search terms shorter than 4 characters or so.

- `like` and `rlike` allow search terms less than 4 characters which is perfect if you have any products with short product codes, but they fail to provide good results when searching by more vague terms.

A possible solution to this dilemma could be to add a similar dropdown menu for the customer to choose how they would like to search, maybe only in the advanced search section, though I doubt the vast majority of customers would get much use from such a feature.