### PR TITLE
Fix Unavailable button appearance on category page

### DIFF
--- a/skins/foundation/templates/content.category.php
+++ b/skins/foundation/templates/content.category.php
@@ -105,7 +105,7 @@
                   {if $product.available <= 0}
                   <div class="row collapse">
                      <div class="small-12 columns">
-                        <input type="submit" value="{$LANG.common.unavailable}" class="button small disabled expand marg-top" disabled>
+                        <input type="submit" value="{$LANG.common.unavailable}" class="button small postfix disabled expand marg-top" disabled>
                      </div>
                   </div>
                   {* ctrl_stock True when a product is considered 'in stock' for purposes of allowing a purchase, either by actually being in stock or via certain settings *}


### PR DESCRIPTION
Same as issue #1040 but on category page (pic taken before fix):
![cc_unavailable](https://cloud.githubusercontent.com/assets/14335170/24921954/7011dfa0-1ea1-11e7-8e21-46b0ba07cdfc.jpg)
