### PR TITLE
Fix unable to hide 'More' pagination button

### DIFF
--- a/skins/foundation/templates/content.category.php
+++ b/skins/foundation/templates/content.category.php
@@ -213,11 +213,12 @@
       </div>
    </div>
    *}
-   {* Add "hide-for-small-up" to the class attribute to not display the more button *}
-   <div class="hide" id="ccScrollCat">{$category.cat_id}</div>
+   {* Add "hide-for-medium-up" to the class attribute to not display the more button *}
+   <div class="hide" id="ccScrollCat">
    {if $page!=='all' && ($page < $total)}
    {$params[$var_name] = $page + 1}
    <a href="{$current}{http_build_query($params)}{$anchor}" data-next-page="{$params[$var_name]}" data-cat="{$category.cat_id}" class="button tiny expand ccScroll-next">{$LANG.common.more} <svg class="icon"><use xlink:href="#icon-angle-down"></use></svg></a>
+   </div>
    {/if}
 </div>
 <div class="hide" id="lang_loading">{$LANG.common.loading}</div>


### PR DESCRIPTION
 Fix issues with 'More' pagination button

- Button could not be hidden if following the instructions given due to
  the div not encompassing the link

- 'hide-for-small-up' prevented the button from appearing for mobile
  devices despite traditional pagination also not appearing there,
  preventing mobile users from being able to go to the next page.

- {$category.cat_id} was displayed as plain text above the 'More' button;
  removing it does not seem to have any effect on functionality.