### PR TITLE
Fix a date format

### DIFF
--- a/classes/catalogue.class.php
+++ b/classes/catalogue.class.php
@@ -386,7 +386,7 @@ class Catalogue {
 							$review['name'] = $GLOBALS['language']->catalogue['review_anon'];
 						}
 						$review['date']  = formatTime($review['time']);
-						$review['date_schema'] = formatTime($review['time'], '%G-%m-%d', true);
+						$review['date_schema'] = formatTime($review['time'], '%Y-%m-%d', true);
 						$review['gravatar'] = md5(strtolower(trim($review['email'])));
 						$review['gravatar_src'] = 'http://www.gravatar.com/avatar/'.$review['gravatar'].'?d=404&r=g';
 						$headers = get_headers($review['gravatar_src']);


### PR DESCRIPTION
Using %G instead of %Y can return the previous year in the early days of some years.