### PR TITLE
classes/seo: remove 'e' flag in preg_match

### DIFF
--- a/classes/seo.class.php
+++ b/classes/seo.class.php
@@ -630,7 +630,7 @@ class SEO
             }
             return $path;
         }
-        if (preg_match('#^(.*/)?[\w]+.[a-z]+\?_a\=([\w]+)(?:\&(amp;)?([\w\[\]]+)\=([\w\-\_]+)([^"\']*))$#ieS', $path, $match)) {
+        if (preg_match('#^(.*/)?[\w]+.[a-z]+\?_a\=([\w]+)(?:\&(amp;)?([\w\[\]]+)\=([\w\-\_]+)([^"\']*))$#iS', $path, $match)) {
             if (in_array($match[2], $this->_static_sections)) {
                 if (!empty($match[4]) && !empty($match[5])) {
                     $match[6] = $match[6].'&'.$match[4].'='.$match[5];


### PR DESCRIPTION
Besides the 'e' flag not doing anything in preg_match, that same flag was removed in PHP 7.0: http://php.net/manual/en/reference.pcre.pattern.modifiers.php