### PR TITLE
Update settings.language.php

### DIFF
--- a/admin/skins/default/templates/settings.language.php
+++ b/admin/skins/default/templates/settings.language.php
@@ -113,7 +113,7 @@
          {/foreach}
          </table>
          {elseif isset($SEARCH_HITS)}
-         <p>{sprinf($LANG.translate.no_phrases_found,$SEARCH_PHRASE)}</p>
+         <p>{sprintf($LANG.translate.no_phrases_found,$SEARCH_PHRASE)}</p>
          {/if}
       {/if}
       {if $SECTIONS}


### PR DESCRIPTION
Language page not loading because of misspelled "sprinf" <-- "sprintf" in v6.5.2