### PR TITLE
Bugfix: `ltrim()` trims too many characters from 404 log URLs

### DIFF
--- a/classes/cubecart.class.php
+++ b/classes/cubecart.class.php
@@ -2122,7 +2122,8 @@ class Cubecart
             
             $GLOBALS['db']->delete('CubeCart_404_log', '`created` < DATE_SUB(NOW(), INTERVAL 90 DAY)');
             $uri = strtok($uri, '?');
-            $uri = str_replace(CC_ROOT_REL, "", $uri);
+	    $cc_root_rel_pattern = "/\A" . preg_quote(CC_ROOT_REL, "/") . "/"
+	    $uri = preg_replace($cc_root_rel_pattern, "", $uri)
             $uri = rtrim($uri, '/');
             $uri = htmlentities($uri, ENT_QUOTES);
         

--- a/classes/cubecart.class.php
+++ b/classes/cubecart.class.php
@@ -2122,7 +2122,7 @@ class Cubecart
             
             $GLOBALS['db']->delete('CubeCart_404_log', '`created` < DATE_SUB(NOW(), INTERVAL 90 DAY)');
             $uri = strtok($uri, '?');
-            $uri = ltrim($uri, CC_ROOT_REL);
+            $uri = str_replace(CC_ROOT_REL, "", $uri);
             $uri = rtrim($uri, '/');
             $uri = htmlentities($uri, ENT_QUOTES);
         


### PR DESCRIPTION
Rather than removing instances of an entire search string from the supplied input string, `ltrim()` removes all characters from the input string that appear _anywhere_ in the search string, until it finds the first character in the input string that doesn't appear in the search string.

When used here in adding URLs to the 404 log table, this means that sometimes additional parts of the URL's path will be removed, depending on your site's `CC_ROOT_REL`.

For example, with the URL `https://example-site.com/online-store/index.php`, the site's `CC_ROOT_REL` will be `/online-store/`, so `ltrim()` will trim the URL to `dex.php` since the `i` and `n` characters at the start of the path appear in `CC_ROOT_REL`. `d` does not appear in `CC_ROOT_REL`, so all characters from that point on are preserved.

Using `preg_replace()` instead ensures that only the exact `CC_ROOT_REL` string is removed from the beginning of the logged URL.

### Related

There's another use of `ltrim()` [in settings.language.inc.php](https://github.com/cubecart/v6/blob/6f2e699cfffab386ddd076b678cc2a6c30327264/admin/sources/settings.language.inc.php#L309) that looks like it also might trim URLs too aggressively, but I'm not familiar with the context of that code so I haven't touched it here.