### PR TITLE
Resolution to issue #3829 - Hookloader error when enabling a new extension

### DIFF
--- a/classes/hookloader.class.php
+++ b/classes/hookloader.class.php
@@ -213,6 +213,7 @@ class HookLoader
         if (!empty($plugin)) {
             $this->_plugin_name($plugin);
             $file = $this->_hook_dir.'/'.$plugin.'/'.'config.xml';
+            $allowed_hooks = array();
             if (file_exists($file)) {
                 // Read each XML file, check contents, and update/add to database
                 try {
@@ -519,3 +520,4 @@ class HookLoader
         return true;
     }
 }
+


### PR DESCRIPTION
Resolves the following error

[<strong>Exception</strong>] .../classes/hookloader.class.php:241 - implode(): Argument #1 ($array) must be of type array, string given