### PR TITLE
Fix syntax for database delete condition

### DIFF
--- a/api.php
+++ b/api.php
@@ -115,7 +115,7 @@ foreach ($GLOBALS['hooks']->load('api.bootstrap') as $hook) {
 // Purge old API log entries (~5% of requests, older than 30 days)
 if (executionChance(5)) {
     $cutoff = time() - (30 * 86400);
-    $GLOBALS['db']->delete('CubeCart_api_log', array('<' => array('request_time' => $cutoff)));
+    $GLOBALS['db']->delete('CubeCart_api_log', array('request_time' => '<'.$cutoff)));
 }
 
 // Route and dispatch


### PR DESCRIPTION
removed the nested arrays for the conditional comparison of the request_time and cutoff correctly delete the old logs and solve the system error log messages of:
	File: [api.php] Line: [124] "DELETE FROM `CubeCart_api_log` WHERE (`<` IN (1773529401)) ;" - Unknown column '<' in 'WHERE'

