### PR TITLE
#4145 - stop abandonment emails going to customers who already bought

### DIFF
--- a/classes/cart.class.php
+++ b/classes/cart.class.php
@@ -1319,10 +1319,14 @@ class Cart
                 $basket = serialize($this->basket['contents']);
                 if (empty($old_basket) || $old_basket != $basket) {
                     $old_basket = $basket;
+                    // `updated` records when the contents last actually changed, which
+                    // is what the abandonment cron compares against the customer's
+                    // orders to tell a live cart from post-purchase residue.
+                    $now = time();
                     if (Database::getInstance()->select('CubeCart_saved_cart', array('basket'), array('customer_id' => $id), false, false, false, false) !== false) {
-                        Database::getInstance()->update('CubeCart_saved_cart', array('basket' => $basket), array('customer_id' => $id));
+                        Database::getInstance()->update('CubeCart_saved_cart', array('basket' => $basket, 'updated' => $now), array('customer_id' => $id));
                     } else {
-                        Database::getInstance()->insert('CubeCart_saved_cart', array('customer_id' => $id, 'basket' => $basket));
+                        Database::getInstance()->insert('CubeCart_saved_cart', array('customer_id' => $id, 'basket' => $basket, 'updated' => $now));
                     }
                 }
             }

--- a/classes/cron.class.php
+++ b/classes/cron.class.php
@@ -108,9 +108,14 @@ class Cron
 
         // Drive off saved_cart so we catch both pre-checkout abandonment (no
         // order_summary row) and checkout abandonment (Pending order at gateway).
-        // The recent-order gate blocks customers who placed a Processing/Complete
-        // order during or just before their most recent session activity — they
-        // already bought something, don't email about leftovers.
+        // The recent-order gate compares the cart against the customer's orders:
+        // if they placed a Processing/Complete order at or after the cart last
+        // changed, what's left is residue from that purchase, not a live basket.
+        // Anchoring on the cart rather than on session activity matters — a repeat
+        // buyer's last session keeps moving forward while the order date does not,
+        // so a session-relative window reopens the moment they come back to browse
+        // and mails them the items they already bought (#4145). Legacy rows have
+        // `updated` = 0, so any completed order suppresses them: fail safe.
         $pfx = $GLOBALS['config']->get('config', 'dbprefix');
         $query = "SELECT sc.customer_id, sc.basket, c.email, c.first_name, c.last_name, c.language, c.currency, c.country
             FROM `{$pfx}CubeCart_saved_cart` sc
@@ -133,10 +138,7 @@ class Cron
                 SELECT 1 FROM `{$pfx}CubeCart_order_summary` os
                 WHERE os.customer_id = sc.customer_id
                   AND os.status IN (2, 3)
-                  AND os.order_date >= COALESCE((
-                    SELECT MAX(s3.session_last) FROM `{$pfx}CubeCart_sessions` s3
-                    WHERE s3.customer_id = sc.customer_id
-                  ), 0) - ".(int)$delay."
+                  AND os.order_date >= sc.updated
               )";
 
         $results = $GLOBALS['db']->query($query);

--- a/classes/db/schema/structure.sql
+++ b/classes/db/schema/structure.sql
@@ -1003,6 +1003,7 @@ CREATE TABLE IF NOT EXISTS `CubeCart_reviews` (
 CREATE TABLE IF NOT EXISTS `CubeCart_saved_cart` (
   `customer_id` INT UNSIGNED NOT NULL,
   `basket` mediumblob NOT NULL,
+  `updated` INT UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`customer_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci; #EOQ
 

--- a/classes/order.class.php
+++ b/classes/order.class.php
@@ -660,6 +660,21 @@ class Order
                 }
             }
 
+            // Payment landed, so whatever is still in the customer's saved cart is
+            // purchase residue. It is otherwise only cleared by the shopper landing
+            // back on the receipt page (CubeCart::_complete), which never happens
+            // when the gateway confirms asynchronously or the tab is closed — and
+            // the abandonment cron then emails them the items they just bought.
+            // Restricted to carts untouched since the order was placed, so a shopper
+            // who started a new basket while a slow callback was in flight keeps it.
+            // Legacy rows have `updated` = 0 and are always cleared, which drains
+            // residue that pre-dates this fix.
+            if ((int)$currentStatus[0]['status'] === self::ORDER_PENDING
+                && in_array((int)$status_id, array(self::ORDER_PROCESS, self::ORDER_COMPLETE), true)
+                && !empty($this->_order_summary['customer_id'])) {
+                $GLOBALS['db']->delete('CubeCart_saved_cart', '`customer_id` = '.(int)$this->_order_summary['customer_id'].' AND `updated` <= '.(int)$this->_order_summary['order_date']);
+            }
+
             // Update Stock Levels
             $this->_manageStock($status_id, $order_id);
 

--- a/setup/db/upgrade/6.7.6.sql
+++ b/setup/db/upgrade/6.7.6.sql
@@ -1,2 +1,3 @@
 DELETE FROM `CubeCart_image_index` WHERE `product_id` = 0; #EOQ
 ALTER TABLE `CubeCart_search` ADD INDEX `searchstr` (`searchstr`); #EOQ
+ALTER TABLE `CubeCart_saved_cart` ADD COLUMN `updated` INT UNSIGNED NOT NULL DEFAULT 0; #EOQ


### PR DESCRIPTION
Follow-up to #4145. Reported again via support: customers receiving "You left items in your cart" emails listing books they had already bought and paid for.

## Evidence

From an affected live store (6.7.5):

- **107 of 133** abandonment sends went to customers whose most recent order was already Processing or Complete. Only 7 were legitimate.
- **409 of 698** `CubeCart_saved_cart` rows were purchase residue.
- One customer's saved cart held product ids `8491/8834/8835/8837` — byte-for-byte the four items on his paid Stripe order from a week earlier. He was emailed those four books.

## Cause 1 — the saved cart is never cleared unless the shopper sees the receipt

`CubeCart_saved_cart` is deleted in exactly one place, `Cart::clear()`, whose only checkout call site is the receipt page in `CubeCart::_complete()`. That requires the session to still hold `cart_order_id`. Any order confirmed by an async gateway callback, or where the shopper closed the tab, leaves the purchased basket behind permanently. `Order::orderStatus()` never touched it.

Fixed by dropping the row when payment lands (Pending → Processing/Complete), restricted to carts untouched since the order so a basket started during a slow callback survives.

## Cause 2 — the suppression gate was anchored to session activity

The 6.7.5 gate compared `os.order_date` against `MAX(session_last) - delay`. A repeat buyer's last session moves forward every visit while the order date does not, so the window reopens the moment they come back to browse.

Worked example: customer ordered 2026-06-05 (Complete), emailed 2026-08-03. The other clauses pin `MAX(session_last)` into 07-27..08-02; suppression would have required it to be `<= 06-06`. The gate could not fire.

Now anchored to the cart itself — a Processing/Complete order at or after the cart last changed means the cart is residue. Needs a new `updated` column on `CubeCart_saved_cart`, stamped by `Cart::save()`. Legacy rows keep `0`, so any completed order suppresses them: fail safe, and it drains pre-existing residue without a data migration.

## Verification

Gate predicate tested against a real database:

| scenario | outcome |
|---|---|
| Bought after last cart change (the reported case) | suppressed |
| New cart built *after* an order | email sent — recovery still works |
| Legacy row, `updated = 0` | suppressed |
| Never ordered | email sent |

Schema change ships in both `classes/db/schema/structure.sql` (fresh install) and `setup/db/upgrade/6.7.6.sql` (upgrade), as a plain `ALTER TABLE ... ADD COLUMN` — no prepared statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)