### PR TITLE
#4209 - Admin: filter and highlight the product category picker

### DIFF
--- a/admin/skins/default/js/admin.js
+++ b/admin/skins/default/js/admin.js
@@ -1901,3 +1901,79 @@ function ccRepositionActiveTab() {
 $(document).ready(ccRepositionActiveTab);
 $(window).on('load resize', ccRepositionActiveTab);
 $(document).on('click', '#tab_control .tab', function() { setTimeout(ccRepositionActiveTab, 0); });
+
+
+/* Product > Categories tab: client-side filter and selected-row highlighting.
+   See cubecart/v6#4209 — the list is one row per category (hundreds on some
+   stores), and because input[type=checkbox] is opacity:0 the tick is easy to
+   miss, so make selections obvious and let the list be narrowed by name.
+   Rows are hidden, never removed, so the checkboxes of filtered-out categories
+   still submit and no assignment is lost on save. */
+function ccCategoryPickerInit() {
+    var $table = $('#cat_table');
+    if (!$table.length) return;
+
+    var $rows = $table.find('tbody tr.cat-row'),
+        $input = $('#cat_filter_input'),
+        $selectedOnly = $('#cat_filter_selected'),
+        $noMatch = $('#cat_no_match'),
+        $count = $('#cat_filter_count'),
+        countLang = $count.data('lang') || '%1$s';
+
+    // Cache the lowercased path once — filtering runs on every keystroke.
+    $rows.each(function() {
+        this.ccCatName = $(this).find('.cat-name').text().toLowerCase();
+    });
+
+    // Highlight and count. Deliberately does not touch visibility: unticking a
+    // row while "selected only" is on must not make it vanish under the cursor.
+    function refreshState() {
+        var checked = 0;
+        $rows.each(function() {
+            var $row = $(this),
+                on = $row.find('input.check_cat').prop('checked');
+            if (on) checked++;
+            $row.toggleClass('is-checked', !!on)
+                .toggleClass('is-primary', $row.find('input.check-primary').prop('checked'));
+        });
+        $count.text(countLang.replace('%1$s', checked));
+    }
+
+    // Reads is-checked, so refreshState() must have run first.
+    function refreshVisibility() {
+        var term = $.trim($input.val() || '').toLowerCase(),
+            selectedOnly = $selectedOnly.prop('checked'),
+            shown = 0;
+        $rows.each(function() {
+            var $row = $(this),
+                visible = (!selectedOnly || $row.hasClass('is-checked')) &&
+                          (!term || this.ccCatName.indexOf(term) !== -1);
+            $row.toggleClass('is-hidden', !visible);
+            if (visible) shown++;
+        });
+        $noMatch.toggleClass('is-hidden', shown !== 0);
+    }
+
+    // Check/uncheck all applies to the rows currently in view only — with a
+    // filter active, silently clearing categories the admin cannot see would be
+    // a trap. Hence its own handler rather than the generic .check-all one.
+    $('#cat_check_all').on('change', function() {
+        var on = this.checked;
+        $rows.not('.is-hidden').find('input.check_cat').prop('checked', on).each(function() {
+            $(this).parent('.custom-checkbox').toggleClass('selected', on);
+        });
+        refreshState();
+    });
+
+    $input.on('input search', refreshVisibility);
+    $selectedOnly.on('change', refreshVisibility);
+    // Deferred: the .check-primary handler ticks its own checkbox on click
+    // without firing change, so read the state after it has run.
+    $table.on('change click', 'input.check_cat, input.check-primary', function() {
+        setTimeout(refreshState, 0);
+    });
+
+    refreshState();
+    refreshVisibility();
+}
+$(document).ready(ccCategoryPickerInit);

--- a/admin/skins/default/styles/layout.css
+++ b/admin/skins/default/styles/layout.css
@@ -2798,6 +2798,9 @@ textarea#query {
   --rowOdd: transparent;
   --rowEven: transparent;
   --rowHover: var(--highlight);
+  /* Ticked row in a picker list. Must stay distinct from both --bg and
+     --highlight, since --highlight is already the zebra stripe. */
+  --rowSelected: #d7e9f0;
 }
 
 /* ===== DARK THEME OVERRIDES ===== */
@@ -2832,6 +2835,7 @@ textarea#query {
     --rowOdd: #161a1f;
     --rowEven: #13171b;
     --rowHover: #20262c;
+    --rowSelected: #1d3a44;
 
     --btn-bg: #2a3036;
     --btn-bg-hover: #343a40;
@@ -3962,3 +3966,18 @@ body.chromeless #content_body { border-left: 0; }
 
 /* Withdrawal detail tables — label column bold, left-aligned */
 .wd-detail-table td.wd-label { font-weight:700; vertical-align:top; white-space:nowrap; }
+
+/* Product > Categories tab (cubecart/v6#4209). Stores with many categories get
+   an unscannable list, and because input[type=checkbox] is opacity:0 (the tick
+   is the .custom-checkbox sprite) an already-assigned category is easy to miss
+   — worse in dark mode. Filter box + whole-row highlight fixes both. */
+.cat-filter { display:flex; flex-wrap:wrap; align-items:center; gap:12px; margin:0 0 8px; }
+.cat-filter__input { flex:1 1 240px; max-width:420px; }
+.cat-filter__toggle { display:flex; align-items:center; gap:6px; white-space:nowrap; cursor:pointer; }
+.cat-filter__count { color:var(--text-light); font-size:11px; }
+
+/* !important: the dark-theme block sets tbody td backgrounds with !important. */
+#cat_table tbody tr.cat-row.is-checked > td { background-color:var(--rowSelected) !important; }
+#cat_table tbody tr.cat-row.is-checked > td:first-child { box-shadow:inset 3px 0 0 var(--primary-accent); }
+#cat_table tbody tr.cat-row.is-primary > td.cat-name { font-weight:700; }
+#cat_table tbody tr.is-hidden { display:none; }

--- a/admin/skins/default/templates/products.index.php
+++ b/admin/skins/default/templates/products.index.php
@@ -439,7 +439,12 @@
    </div>
    <div id="category" class="tab_content">
       <h3>{$LANG.settings.title_categories}</h3>
-      <table>
+      <div class="cat-filter">
+         <input type="search" id="cat_filter_input" class="textbox cat-filter__input" placeholder="{$LANG.common.type_to_search}" autocomplete="off" aria-controls="cat_table">
+         <label class="cat-filter__toggle" for="cat_filter_selected"><input type="checkbox" id="cat_filter_selected"> {$LANG.catalogue.category_selected_only}</label>
+         <span id="cat_filter_count" class="cat-filter__count" data-lang="{$LANG.catalogue.category_selected_count}"></span>
+      </div>
+      <table id="cat_table">
          <thead>
             <tr>
                <th>{$LANG.catalogue.category_primary}</th>
@@ -449,17 +454,18 @@
          </thead>
          <tbody>
             {foreach from=$CATEGORIES item=category}
-            <tr>
+            <tr class="cat-row">
                <td style="text-align:center"><input type="radio" name="primary_cat" class="check-primary" value="{$category.id}" rel="cat_{$category.id}"{$category.primary}></td>
                <td style="text-align:center"><input type="checkbox" id="cat_{$category.id}" name="categories[{$category.id}]" value="{$category.id}" class="check_cat" {$category.selected}></td>
-               <td>{$category.name}</td>
+               <td class="cat-name">{$category.name}</td>
             </tr>
             {/foreach}
+            <tr id="cat_no_match" class="is-hidden"><td colspan="3">{$LANG.common.error_no_results}</td></tr>
          </tbody>
          <tfoot>
             <tr>
                <td>&nbsp;</td>
-               <td style="text-align:center"><input type="checkbox" class="check-all" rel="check_cat"></td>
+               <td style="text-align:center"><input type="checkbox" id="cat_check_all"></td>
                <td><strong>{$LANG.form.check_uncheck}</strong></td>
             </tr>
          </tfoot>

--- a/language/definitions.xml
+++ b/language/definitions.xml
@@ -355,6 +355,8 @@
     <string name="category_add" introduced="5.0.0"><![CDATA[Add Category]]></string>
     <string name="category_additional" introduced="5.0.0"><![CDATA[Additional]]></string>
     <string name="category_primary" introduced="5.0.0"><![CDATA[Primary]]></string>
+    <string name="category_selected_count" introduced="6.7.6"><![CDATA[%1$s selected]]></string>
+    <string name="category_selected_only" introduced="6.7.6"><![CDATA[Selected only]]></string>
     <string name="checkout_latest_products" introduced="5.0.0"><![CDATA[Check out these great products...]]></string>
     <string name="click_enlarge" introduced="5.0.0"><![CDATA[Click to enlarge]]></string>
     <string name="condition" introduced="5.0.0"><![CDATA[Condition]]></string>


### PR DESCRIPTION
Closes #4209.

The product Categories tab renders one row per category, which is unscannable on stores with a large tree. Selections are also easy to miss: `input[type=checkbox]` is `opacity:0` in this skin, so the only cue is a 16px sprite on the wrapping `.custom-checkbox` — which is what the reporter hit, and worse in dark mode.

Adds a client-side filter over the category path, a "Selected only" toggle and a live count, and highlights ticked rows with a tinted background plus a left accent bar. The primary category is shown bold.

A new `--rowSelected` variable is defined for both themes so the tint stays distinct from the zebra stripe, which already uses `--highlight`.

## Behaviour notes

- Rows are hidden, never removed, so filtered-out checkboxes still submit and no assignment is lost on save.
- Check/uncheck all is scoped to the visible rows via its own handler, so an active filter cannot silently clear categories the admin cannot see. It no longer uses the shared `.check-all` handler, so no other screen is affected.
- Visibility is only recomputed when the filter inputs change, so unticking a row while "Selected only" is on does not make it vanish under the cursor.

Two new `catalogue` language strings; the placeholder and empty state reuse existing `common.*` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)