### PR TITLE
#4229 - restore Smarty template dir when a module template is missing

### DIFF
--- a/classes/module.class.php
+++ b/classes/module.class.php
@@ -99,6 +99,11 @@ class Module
 	public function fetch()
 	{
 		if (!$GLOBALS['smarty']->templateExists($this->_template)) {
+			// _setupTemplate() has already pointed Smarty at the module's own skin
+			// directory. Restore it before bailing out, or whatever renders next -
+			// the admin wrapper's templates/main.php - is looked for in there and
+			// the page dies with "Unable to load template".
+			$GLOBALS['gui']->changeTemplateDir();
 			return false;
 		}
 		foreach ($this->_template_data as $key => $value) {


### PR DESCRIPTION
Fixes #4229

`Module::fetch()` returned early when the module template could not be resolved, without restoring the Smarty template directory that `_setupTemplate()` had already pointed at the module's own `skin` folder. Everything rendered afterwards — including the admin wrapper's `templates/main.php` — was then looked for inside the module folder, so the admin page died with an uncaught Smarty exception and displayed blank.

The restore call at the end of `fetch()` is only reached on the success path, so the early return leaked the changed directory into the rest of the request.

Restores the template directory before returning.

Reproduced on 6.7.6 via `/admin.php?_g=plugins&type=gateway&module=Print_Order_Form` — `Print_Order_Form` is the only stock gateway module that ships a `skin` directory, which is why other gateway modules are unaffected.

Not limited to that module: any module whose template cannot be resolved took the whole admin page down rather than failing quietly.
