### PR TITLE
#4246 - re-add restocked products to the Elasticsearch index

### DIFF
--- a/classes/elasticsearchhandler.class.php
+++ b/classes/elasticsearchhandler.class.php
@@ -617,6 +617,15 @@ class ElasticsearchHandler
             if($field === 'stock_level' && $this->_isOutOfStock()) {
                 return $this->delete($id);
             }
+            // A sold-out product was removed from the index by the branch above.
+            // If it is restocked later, a partial update targets a document that
+            // no longer exists and throws document_missing, so the product never
+            // returns to the index. Re-add it in full instead: on the stock_level
+            // path $_index_body carries only the stock flags, so an upsert would
+            // leave a document with no name, price or description.
+            if(!$this->exists($id)) {
+                return $this->add($id);
+            }
             return $this->_client->update($params);
         } catch (Exception $e) {
             $this->_logError($e->getMessage());


### PR DESCRIPTION
update() chose between patching and creating a document by testing whether the index existed, not the document. With es_is enabled a sold-out product is deleted from the index by the branch just above, so a missing document is routine rather than an index-level failure. On restock the partial update hit a deleted id, Elasticsearch threw document_missing, and the catch swallowed it into an E_USER_NOTICE. The product stayed buyable in the catalogue but was invisible to search until a full rebuild.

Check for the document the way products.index.inc.php and the Data Pump importer already do, and fall back to add() so the whole body is rebuilt. An upsert would not do: on the stock_level path _index_body carries only the stock flags.