### PR TITLE
Require the captcha on every submission, not once per session

### DIFF
--- a/classes/gui.class.php
+++ b/classes/gui.class.php
@@ -37,6 +37,9 @@ class GUI
      * @var array
      */
     public $_product_images = array();
+
+    /** @var bool Captcha solved on THIS request. Not persisted: each submission must solve again. */
+    private $_recaptcha_confirmed = false;
     
     /**
      * Do we have any sale items?
@@ -740,7 +743,7 @@ class GUI
      */
     public function recaptchaRequired()
     {
-        if ($GLOBALS['config']->get('config', 'recaptcha') && !$GLOBALS['session']->get('confirmed', 'recaptcha')) {
+        if ($GLOBALS['config']->get('config', 'recaptcha') && !$this->_recaptcha_confirmed) {
             $GLOBALS['smarty']->assign('RECAPTCHA', $GLOBALS['config']->get('config', 'recaptcha'));
             return true;
         }
@@ -827,6 +830,7 @@ class GUI
                 }
             }
             $GLOBALS['session']->set('', $recaptcha, 'recaptcha');
+            $this->_recaptcha_confirmed = !empty($recaptcha['confirmed']);
         } elseif (!$GLOBALS['session']->get('confirmed', 'recaptcha')) {
             $GLOBALS['session']->delete('', 'recaptcha');
         }


### PR DESCRIPTION
recaptchaRequired() short-circuited on a session flag, so once a visitor solved the challenge on any form every other protected form in that session rendered without a captcha and skipped verification. A bot solving once could then post freely.

The confirmation is now request-scoped, so each submission is challenged.

Note that recaptchaRequired() is also used by the controllers as the "captcha not satisfied" test after recaptchaValidate() has run, so it cannot simply return true whenever a captcha is configured; that would make every protected form permanently unsubmittable.

Fixes #4251